### PR TITLE
Ad explicit polymer-dom import to enable calling the register-function

### DIFF
--- a/theme/lumo/vcf-autocomplete-styles.js
+++ b/theme/lumo/vcf-autocomplete-styles.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/style';
+import '@polymer/polymer/lib/elements/dom-module.js';
 
 const theme = document.createElement('dom-module');
 theme.id = 'vcf-autocomplete-lumo';


### PR DESCRIPTION
This fixes the problem reported in vaadin-component-factory/autocomplete#17.